### PR TITLE
Added missing python dependency (python-dateutil) and service which creates a folders in /run

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,6 +65,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     'recipe[python]',
 
     'recipe[vagrant-tiles::setup_python_dateutil]',
+    'recipe[vagrant-tiles::setup_tileinit]',
 
     'recipe[vagrant-tiles::setup_paths]',
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,6 +64,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     'recipe[git]',
     'recipe[python]',
 
+    'recipe[vagrant-tiles::setup_python_dateutil]',
+
     'recipe[vagrant-tiles::setup_paths]',
 
     'recipe[vagrant-tiles::pg_gem_workaround]',

--- a/recipes/setup_python_dateutil.rb
+++ b/recipes/setup_python_dateutil.rb
@@ -1,0 +1,6 @@
+include_recipe 'python'
+include_recipe "python::pip"
+
+python_pip "python-dateutil" do
+    action :install
+end

--- a/recipes/setup_tileinit.rb
+++ b/recipes/setup_tileinit.rb
@@ -1,0 +1,20 @@
+file '/etc/init.d/tileinit' do
+    mode '0744'
+    owner 'root'
+    group 'root'
+    content <<-EOF
+#!/bin/bash
+mkdir /run/tileserver
+chmod 0777 /run/tileserver
+
+mkdir /run/tilequeue
+chmod 0777 /run/tilequeue
+
+mkdir /run/osm2pgsql
+chmod 0777 /run/osm2pgsql
+    EOF
+end
+
+bash 'install tileinit service' do
+    code 'update-rc.d tileinit defaults 10'
+end


### PR DESCRIPTION
`python-dateutil` is required by tileserver.

In latests Debian (and Ubuntu) versions you need a root permissions to create files and folders in `/run` (and `/var/run`) folder. The simplest way that I see is create a new linux service which will create this folders with proper rights (0777 exactly, just because it's a development service and nobody cares) before ant other tile service will start (priority 10 in rc.d)

I'll appreciate if anybody will fix my crazy way with `/run` folders.
